### PR TITLE
reg: rename Bytes() to Size()

### DIFF
--- a/build/pseudo.go
+++ b/build/pseudo.go
@@ -39,7 +39,7 @@ func (c *Context) Load(src gotypes.Component, dst reg.Register) reg.Register {
 		c.adderror(err)
 		return dst
 	}
-	c.mov(b.Addr, dst, int(gotypes.Sizes.Sizeof(b.Type)), int(dst.Bytes()), b.Type)
+	c.mov(b.Addr, dst, int(gotypes.Sizes.Sizeof(b.Type)), int(dst.Size()), b.Type)
 	return dst
 }
 
@@ -51,7 +51,7 @@ func (c *Context) Store(src reg.Register, dst gotypes.Component) {
 		c.adderror(err)
 		return
 	}
-	c.mov(src, b.Addr, int(src.Bytes()), int(gotypes.Sizes.Sizeof(b.Type)), b.Type)
+	c.mov(src, b.Addr, int(src.Size()), int(gotypes.Sizes.Sizeof(b.Type)), b.Type)
 }
 
 // Dereference loads a pointer and returns its element type.

--- a/operand/checks.go
+++ b/operand/checks.go
@@ -132,7 +132,7 @@ func IsYMM(op Op) bool {
 // IsRegisterKindSize returns true if op is a register of the given kind and size in bytes.
 func IsRegisterKindSize(op Op, k reg.Kind, n uint) bool {
 	r, ok := op.(reg.Register)
-	return ok && r.Kind() == k && r.Bytes() == n
+	return ok && r.Kind() == k && r.Size() == n
 }
 
 // IsRegisterKind returns true if op is a register of the given kind.

--- a/reg/collection.go
+++ b/reg/collection.go
@@ -13,11 +13,11 @@ func NewCollection() *Collection {
 	}
 }
 
-// VirtualRegister allocates and returns a new virtual register of the given kind and size.
-func (c *Collection) VirtualRegister(k Kind, s Size) Virtual {
+// VirtualRegister allocates and returns a new virtual register of the given kind and width.
+func (c *Collection) VirtualRegister(k Kind, w Width) Virtual {
 	vid := c.vid[k]
 	c.vid[k]++
-	return NewVirtual(vid, k, s)
+	return NewVirtual(vid, k, w)
 }
 
 // GP8 allocates and returns a general-purpose 8-bit register.
@@ -32,8 +32,8 @@ func (c *Collection) GP32() GPVirtual { return c.GP(B32) }
 // GP64 allocates and returns a general-purpose 64-bit register.
 func (c *Collection) GP64() GPVirtual { return c.GP(B64) }
 
-// GP allocates and returns a general-purpose register of the given size.
-func (c *Collection) GP(s Size) GPVirtual { return newgpv(c.VirtualRegister(KindGP, s)) }
+// GP allocates and returns a general-purpose register of the given width.
+func (c *Collection) GP(w Width) GPVirtual { return newgpv(c.VirtualRegister(KindGP, w)) }
 
 // XMM allocates and returns a 128-bit vector register.
 func (c *Collection) XMM() VecVirtual { return c.Vec(B128) }
@@ -44,5 +44,5 @@ func (c *Collection) YMM() VecVirtual { return c.Vec(B256) }
 // ZMM allocates and returns a 512-bit vector register.
 func (c *Collection) ZMM() VecVirtual { return c.Vec(B512) }
 
-// Vec allocates and returns a vector register of the given size.
-func (c *Collection) Vec(s Size) VecVirtual { return newvecv(c.VirtualRegister(KindVector, s)) }
+// Vec allocates and returns a vector register of the given width.
+func (c *Collection) Vec(w Width) VecVirtual { return newvecv(c.VirtualRegister(KindVector, w)) }

--- a/reg/reg_test.go
+++ b/reg/reg_test.go
@@ -2,10 +2,10 @@ package reg
 
 import "testing"
 
-func TestSpecBytes(t *testing.T) {
+func TestSpecSize(t *testing.T) {
 	cases := []struct {
-		Spec  Spec
-		Bytes uint
+		Spec Spec
+		Size uint
 	}{
 		{S0, 0},
 		{S8L, 1},
@@ -18,8 +18,8 @@ func TestSpecBytes(t *testing.T) {
 		{S512, 64},
 	}
 	for _, c := range cases {
-		if c.Spec.Size() != c.Bytes {
-			t.Errorf("%v.Bytes() = %d; expect = %d", c.Spec, c.Spec.Size(), c.Bytes)
+		if c.Spec.Size() != c.Size {
+			t.Errorf("%v.Size() = %d; expect = %d", c.Spec, c.Spec.Size(), c.Size)
 		}
 	}
 }

--- a/reg/reg_test.go
+++ b/reg/reg_test.go
@@ -18,8 +18,8 @@ func TestSpecBytes(t *testing.T) {
 		{S512, 64},
 	}
 	for _, c := range cases {
-		if c.Spec.Bytes() != c.Bytes {
-			t.Errorf("%v.Bytes() = %d; expect = %d", c.Spec, c.Spec.Bytes(), c.Bytes)
+		if c.Spec.Size() != c.Bytes {
+			t.Errorf("%v.Bytes() = %d; expect = %d", c.Spec, c.Spec.Size(), c.Bytes)
 		}
 	}
 }

--- a/reg/types.go
+++ b/reg/types.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 )
 
-// Width is a register size.
+// Width is a register width.
 type Width uint
 
-// Typical register sizes.
+// Typical register width values.
 const (
 	B8 Width = 1 << iota
 	B16
@@ -19,7 +19,7 @@ const (
 	B512
 )
 
-// Size returns the register size in bytes.
+// Size returns the register width in bytes.
 func (w Width) Size() uint { return uint(w) }
 
 // Kind is a class of registers.
@@ -229,7 +229,7 @@ func (s Spec) Mask() uint16 {
 	return uint16(s)
 }
 
-// Size returns the register size in bytes.
+// Size returns the register width in bytes.
 func (s Spec) Size() uint {
 	x := uint(s)
 	return (x >> 1) + (x & 1)


### PR DESCRIPTION
It was pointed out #73 that `Bytes()` is a poor name for the size of the register in bytes. In idiomatic Go you would probably expect a `Bytes()` method to return `[]byte`.

This diff changes the `Bytes()` to `Size()`. As a result the `Size` type also needed to be renamed, and `Width` seemed a reasonable choice.