### PR TITLE
lint: stop using deprecated go/packages api

### DIFF
--- a/build/context.go
+++ b/build/context.go
@@ -35,7 +35,7 @@ func NewContext() *Context {
 // Package sets the package the generated file will belong to. Required to be able to reference types in the package.
 func (c *Context) Package(path string) {
 	cfg := &packages.Config{
-		Mode: packages.LoadAllSyntax,
+		Mode: packages.LoadSyntax,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {

--- a/build/context.go
+++ b/build/context.go
@@ -35,7 +35,7 @@ func NewContext() *Context {
 // Package sets the package the generated file will belong to. Required to be able to reference types in the package.
 func (c *Context) Package(path string) {
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedSyntax | packages.NeedTypesInfo,
+		Mode: packages.NeedTypes | packages.NeedDeps,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {

--- a/build/context.go
+++ b/build/context.go
@@ -35,7 +35,7 @@ func NewContext() *Context {
 // Package sets the package the generated file will belong to. Required to be able to reference types in the package.
 func (c *Context) Package(path string) {
 	cfg := &packages.Config{
-		Mode: packages.LoadSyntax,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedSyntax | packages.NeedTypesInfo,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {

--- a/gotypes/signature_test.go
+++ b/gotypes/signature_test.go
@@ -51,7 +51,7 @@ func TestLookupSignatureErrors(t *testing.T) {
 func LoadPackageTypes(t *testing.T, path string) *types.Package {
 	t.Helper()
 	cfg := &packages.Config{
-		Mode: packages.LoadTypes,
+		Mode: packages.LoadImports | packages.NeedTypes | packages.NeedTypesSizes,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {

--- a/gotypes/signature_test.go
+++ b/gotypes/signature_test.go
@@ -51,7 +51,7 @@ func TestLookupSignatureErrors(t *testing.T) {
 func LoadPackageTypes(t *testing.T, path string) *types.Package {
 	t.Helper()
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesSizes,
+		Mode: packages.NeedTypes,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {

--- a/gotypes/signature_test.go
+++ b/gotypes/signature_test.go
@@ -51,7 +51,7 @@ func TestLookupSignatureErrors(t *testing.T) {
 func LoadPackageTypes(t *testing.T, path string) *types.Package {
 	t.Helper()
 	cfg := &packages.Config{
-		Mode: packages.LoadImports | packages.NeedTypes | packages.NeedTypesSizes,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps | packages.NeedTypes | packages.NeedTypesSizes,
 	}
 	pkgs, err := packages.Load(cfg, path)
 	if err != nil {


### PR DESCRIPTION
Fixes #86