### PR TITLE
Added support for AVX512 opmask registers (K0-K7)

### DIFF
--- a/reg/collection.go
+++ b/reg/collection.go
@@ -52,3 +52,6 @@ func (c *Collection) ZMM() VecVirtual { return c.Vec(S512) }
 
 // Vec allocates and returns a vector register of the given width.
 func (c *Collection) Vec(s Spec) VecVirtual { return newvecv(c.VirtualRegister(KindVector, s)) }
+
+// OM allocates and returns an opmask register.
+func (c *Collection) OM(s Spec) OMVirtual { return newomv(c.VirtualRegister(KindOpmask, s)) }

--- a/reg/reg_test.go
+++ b/reg/reg_test.go
@@ -19,6 +19,7 @@ func TestIDIsVirtual(t *testing.T) {
 	cases := []Virtual{
 		GeneralPurpose.Virtual(42, S64),
 		Vector.Virtual(42, S128),
+		Opmask.Virtual(42, S64),
 	}
 	for _, r := range cases {
 		if !r.ID().IsVirtual() {
@@ -28,7 +29,7 @@ func TestIDIsVirtual(t *testing.T) {
 }
 
 func TestIDIsPhysical(t *testing.T) {
-	cases := []Physical{AL, AH, AX, EAX, RAX, X1, Y2, Z31}
+	cases := []Physical{AL, AH, AX, EAX, RAX, X1, Y2, Z31, K1}
 	for _, r := range cases {
 		if !r.ID().IsPhysical() {
 			t.FailNow()
@@ -98,6 +99,9 @@ func TestFamilyLookup(t *testing.T) {
 		{Vector, 27, S512, Z27},
 		{Vector, 1, S16, nil},
 		{Vector, 299, S256, nil},
+		{Opmask, 1, S64, K1},
+		{Opmask, 8, S64, nil},
+		{Opmask, 0, S64, K0},
 	}
 	for _, c := range cases {
 		got := c.Family.Lookup(c.ID, c.Spec)
@@ -156,6 +160,8 @@ func TestLookupPhysical(t *testing.T) {
 		{KindVector, 7, S128, X7},
 		{KindVector, 17, S256, Y17},
 		{KindVector, 27, S512, Z27},
+
+		{KindOpmask, 1, S64, K1},
 	}
 	for _, c := range cases {
 		if got := LookupPhysical(c.Kind, c.Index, c.Spec); !Equal(got, c.Expect) {
@@ -165,7 +171,7 @@ func TestLookupPhysical(t *testing.T) {
 }
 
 func TestLookupIDSelf(t *testing.T) {
-	cases := []Physical{AL, AH, AX, EAX, RAX, X1, Y2, Z31}
+	cases := []Physical{AL, AH, AX, EAX, RAX, X1, Y2, Z31, K1}
 	for _, r := range cases {
 		if got := LookupID(r.ID(), r.spec()); !Equal(got, r) {
 			t.FailNow()


### PR DESCRIPTION
Here's the result of a couple of hours of work learning how the register allocation code works and implementing the AVX512 opmask registers within the existing framework as I understand it. So this is a proposed stepping stone towards https://github.com/mmcloughlin/avo/issues/20

@lukechampine If merged, this code should also remove the need for you to define and explicitly manage opmask registers as in this code: 

https://github.com/lukechampine/blake3/blob/59a82aea36b67f99eb83ea2d12bb378392e234a1/avo/gen.go#L543-L545

The only real question I had with this code is how to properly account for the special treatment of the K0 register in AVX512.

My understanding from the Intel docs is that K0 is a real register just like K1-K7, and can be used for memory operations and to hold constants or temp intermediate values in calculations involving the other opmask registers, but the value stored in K0 can never be directly used as an actual opmask for general AVX512 SIMD instructions, because in that context specifying K0 means "all bits set"/"no mask" (which is also the default when no opmask register is specified at all).

So in this PR I treated it in much the same way as the SP register, that is, K0 is defined both as a pseudo-register (intended when used as an opmask), and a restricted physical register (when explicitly named and used for opmask ALU-type computations). However, because it is restricted, it will never be allocated as a virtual register.

Please review and let me know what you think.