### PR TITLE
internal/cmd/avogen: write output file even when gofmt fails

### DIFF
--- a/internal/cmd/avogen/main.go
+++ b/internal/cmd/avogen/main.go
@@ -73,13 +73,14 @@ func main() {
 	}
 
 	// Generate output.
-	b, err := g.Generate(is)
-	if err != nil {
-		log.Fatal(err)
-	}
+	b, generr := g.Generate(is)
 
 	// Write.
 	if _, err := w.Write(b); err != nil {
 		log.Fatal(err)
+	}
+
+	if generr != nil {
+		log.Fatal(generr)
 	}
 }

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -32,7 +32,7 @@ func GoFmt(i Interface) Interface {
 		}
 		formatted, err := format.Source(b)
 		if err != nil {
-			formatted = b
+			return b, err
 		}
 		return formatted, err
 	})

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -34,6 +34,6 @@ func GoFmt(i Interface) Interface {
 		if err != nil {
 			return b, err
 		}
-		return formatted, err
+		return formatted, nil
 	})
 }

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -30,6 +30,10 @@ func GoFmt(i Interface) Interface {
 		if err != nil {
 			return nil, err
 		}
-		return format.Source(b)
+		formatted, err := format.Source(b)
+		if err != nil {
+			formatted = b
+		}
+		return formatted, err
 	})
 }


### PR DESCRIPTION
This makes it easier to debug avogen:
When you emit invalid syntax,
you can inspect the generated file to determine
what went wrong, instead of having only
gofmt's error to work with.

Signed-off-by: Josh Bleecher Snyder <josharian@gmail.com>