### PR TITLE
simplify dot example

### DIFF
--- a/examples/dot/dot.s
+++ b/examples/dot/dot.s
@@ -16,8 +16,8 @@ TEXT ·Dot(SB), NOSPLIT, $0-52
 	VXORPS Y5, Y5, Y5
 
 blockloop:
-	CMPQ        DX, $0x00000030
-	JL          tail
+	CMPQ        DX, $0x00000000
+	JE          reduce
 	VMOVUPS     (AX), Y6
 	VMOVUPS     32(AX), Y7
 	VMOVUPS     64(AX), Y8
@@ -30,23 +30,12 @@ blockloop:
 	VFMADD231PS 96(CX), Y9, Y3
 	VFMADD231PS 128(CX), Y10, Y4
 	VFMADD231PS 160(CX), Y11, Y5
+	CMPQ        DX, $0x00000030
+	JL          reduce
 	ADDQ        $0x000000c0, AX
 	ADDQ        $0x000000c0, CX
 	SUBQ        $0x00000030, DX
 	JMP         blockloop
-
-tail:
-	VXORPS X6, X6, X6
-
-tailloop:
-	CMPQ        DX, $0x00000000
-	JE          reduce
-	VMOVSS      (AX), X7
-	VFMADD231SS (CX), X7, X6
-	ADDQ        $0x00000004, AX
-	ADDQ        $0x00000004, CX
-	DECQ        DX
-	JMP         tailloop
 
 reduce:
 	VADDPS       Y0, Y1, Y0
@@ -56,7 +45,6 @@ reduce:
 	VADDPS       Y0, Y5, Y0
 	VEXTRACTF128 $0x01, Y0, X1
 	VADDPS       X0, X1, X0
-	VADDPS       X0, X6, X0
 	VHADDPS      X0, X0, X0
 	VHADDPS      X0, X0, X0
 	MOVSS        X0, ret+48(FP)


### PR DESCRIPTION
Thanks for avo, it's a great project!

I noticed that it's possible to simply remove the tail part of SIMD programs and the resulting assembly runs without issues and passes the tests. Avoiding the tailloop makes writing SIMD programs significantly easier and simpler (although in this example it's a relatively minor change). Additionally, the simplification makes the operation ~2.5x faster for inputs of size 512.

This PR is partially a genuine simplification and partially a question of why this doesn't crash?

Notably, I expected 
```
VMOVUPS(x.Offset(32*i), xs[i])
```
to fail, if `x.Offset(32*i)` is out of bounds. But, maybe this actually copies no data and therefore the program doesn't crash?

Using:
```
func BenchmarkDot(b *testing.B) {
	n := 512
	x, y := RandomVector(n), RandomVector(n)
	for i := 0; i < b.N; i++ {
		Dot(x, y)
	}
}
```
It seems the performance is significantly in favor of the simplification:

Current:
```
goos: linux
goarch: amd64
pkg: github.com/mmcloughlin/avo/examples/dot
cpu: AMD Ryzen 5 3600 6-Core Processor              
BenchmarkDot-12    	27368935	       44.80 ns/op
PASS
ok  	github.com/mmcloughlin/avo/examples/dot	1.289s
```

With PR applied:
```
$ go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/mmcloughlin/avo/examples/dot
cpu: AMD Ryzen 5 3600 6-Core Processor              
BenchmarkDot-12    	67842052	       18.01 ns/op
PASS
ok  	github.com/mmcloughlin/avo/examples/dot	1.255s
```
