### PR TITLE
examples: cpu feature checks

### DIFF
--- a/examples/dot/dot_test.go
+++ b/examples/dot/dot_test.go
@@ -3,17 +3,28 @@ package dot
 import (
 	"math/rand"
 	"testing"
+
+	"golang.org/x/sys/cpu"
 )
 
 //go:generate go run asm.go -out dot.s -stubs stub.go
 
+func RequireISAs(t *testing.T) {
+	t.Helper()
+	if !(cpu.X86.HasAVX && cpu.X86.HasFMA) {
+		t.Skip("requires AVX and FMA3 instruction sets")
+	}
+}
+
 func TestEmpty(t *testing.T) {
+	RequireISAs(t)
 	if Dot(nil, nil) != 0.0 {
 		t.Fatal("expect dot product of empty vectors to be zero")
 	}
 }
 
 func TestLengths(t *testing.T) {
+	RequireISAs(t)
 	const epsilon = 0.00001
 	for n := 0; n < 1000; n++ {
 		x, y := RandomVector(n), RandomVector(n)

--- a/examples/geohash/geohash_test.go
+++ b/examples/geohash/geohash_test.go
@@ -1,10 +1,17 @@
 package geohash
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/sys/cpu"
+)
 
 //go:generate go run asm.go -out geohash.s -stubs stub.go
 
 func TestEncodeIntMountEverest(t *testing.T) {
+	if !(cpu.X86.HasSSE2 && cpu.X86.HasBMI2) {
+		t.Skip("requires SSE2 and BMI2 instruction sets")
+	}
 	if EncodeInt(27.988056, 86.925278) != 0xceb7f254240fd612 {
 		t.Fail()
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.11
 
 require (
 	golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
Add necessary feature checks to the `dot` and `geohash` examples to prevent illegal instruction errors.

Fixes #170 #153