### PR TITLE
Allow signed immediates to be matched by IsIMMX functions

### DIFF
--- a/operand/checks.go
+++ b/operand/checks.go
@@ -35,26 +35,30 @@ func IsIMM2U(op Op) bool {
 
 // IsIMM8 returns true is op is an 8-bit immediate.
 func IsIMM8(op Op) bool {
-	_, ok := op.(U8)
-	return ok
+	_, uok := op.(U8)
+	_, iok := op.(I8)
+	return uok || iok
 }
 
 // IsIMM16 returns true is op is a 16-bit immediate.
 func IsIMM16(op Op) bool {
-	_, ok := op.(U16)
-	return ok
+	_, uok := op.(U16)
+	_, iok := op.(I16)
+	return uok || iok
 }
 
 // IsIMM32 returns true is op is a 32-bit immediate.
 func IsIMM32(op Op) bool {
-	_, ok := op.(U32)
-	return ok
+	_, uok := op.(U32)
+	_, iok := op.(I32)
+	return uok || iok
 }
 
 // IsIMM64 returns true is op is a 64-bit immediate.
 func IsIMM64(op Op) bool {
-	_, ok := op.(U64)
-	return ok
+	_, uok := op.(U64)
+	_, iok := op.(I64)
+	return uok || iok
 }
 
 // IsAL returns true if op is the AL register.

--- a/operand/checks_test.go
+++ b/operand/checks_test.go
@@ -36,6 +36,12 @@ func TestChecks(t *testing.T) {
 
 		{IsIMM64, Imm((1 << 64) - 1), true},
 
+		// Signed Immediates
+		{IsIMM8, I8(-1), true},
+		{IsIMM16, I16(-1), true},
+		{IsIMM32, I32(-1), true},
+		{IsIMM64, I64(-1), true},
+
 		// Specific registers
 		{IsAL, reg.AL, true},
 		{IsAL, reg.CL, false},


### PR DESCRIPTION
This has been such a great library for us! But we've been working around an issue concerning immediates that this PR should address. Many of the instruction functions correctly match the size of immediate values, but they only accept unsigned immediates. For example:

```go
r := GP64()
ANDQ(I8(-32), r)   // ANDQ: bad operands
```

While the `imm8` input is checked as expected, the `operand.IsIMM8()` function is causing this check to incorrectly fail.

I believe this PR should address issue #181 