### PR TITLE
script: switch to install.sh from golangci-lint repo

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,7 +5,7 @@ go install ./internal/cmd/asmvet
 
 # Install golangci-lint
 golangci_lint_version='v1.23.6'
-curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin ${golangci_lint_version}
+curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GOPATH/bin ${golangci_lint_version}
 
 # Install tools.
 tools=(
@@ -23,4 +23,3 @@ tools=(
 )
 
 go install -modfile=script/tools.mod "${tools[@]}"
-


### PR DESCRIPTION
The goreleaser script has been deprecated:

https://github.com/goreleaser/godownloader/issues/207