### PR TITLE
tests/thirdparty: fix phoreproject-bls

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -110,7 +110,10 @@ jobs:
           ref: a88a5ae26844d7293359422888d7c7f69f43c845
           path: bls
           persist-credentials: false
-      - name: Setup
+      - name: Setup Root Module
+        working-directory: bls
+        run: go mod tidy
+      - name: Setup Generator Module
         working-directory: bls/asm
         run: |
           sed -i.bak '/+build ignore/d' asm.go

--- a/tests/thirdparty/packages.json
+++ b/tests/thirdparty/packages.json
@@ -59,6 +59,13 @@
         "module": "asm/go.mod",
         "setup": [
             {
+                "name": "Setup Root Module",
+                "commands": [
+                    "go mod tidy"
+                ]
+            },
+            {
+                "name": "Setup Generator Module",
                 "dir": "asm",
                 "commands": [
                     "sed -i.bak '/+build ignore/d' asm.go",


### PR DESCRIPTION
This started failing under Go 1.17.2 due to a missing `go mod tidy` in the
root of the respository.