### PR TITLE
buildtags: Format only go:build lines for go 1.18+

### DIFF
--- a/buildtags/syntax.go
+++ b/buildtags/syntax.go
@@ -33,7 +33,8 @@ func Format(t ConstraintsConvertable) (string, error) {
 	output := ""
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "//") {
+		if (PlusBuildSyntaxSupported() && strings.HasPrefix(line, "// +build")) ||
+			(GoBuildSyntaxSupported() && strings.HasPrefix(line, "//go:build")) {
 			output += line + "\n"
 		}
 	}


### PR DESCRIPTION
```
$ ./tmp/testgo161718.sh ./buildtags/ ./printer/
+ go1.16.8 test ./buildtags/ ./printer/
ok  	github.com/mmcloughlin/avo/buildtags	0.001s
ok  	github.com/mmcloughlin/avo/printer	0.002s
+ go1.17.2 test ./buildtags/ ./printer/
ok  	github.com/mmcloughlin/avo/buildtags	0.001s
ok  	github.com/mmcloughlin/avo/printer	0.002s
+ gotip test ./buildtags/ ./printer/
ok  	github.com/mmcloughlin/avo/buildtags	0.001s
ok  	github.com/mmcloughlin/avo/printer	0.002s
```

Updates #183