### PR TITLE
tests/thirdparty: use shallow clone

### DIFF
--- a/tests/thirdparty/packages_test.go
+++ b/tests/thirdparty/packages_test.go
@@ -71,17 +71,18 @@ func (t *PackageTest) Run() {
 
 // checkout the code at the specified version.
 func (t *PackageTest) checkout() {
-	t.repopath = filepath.Join(t.WorkDir, t.Name())
-
-	// If latest, do a regular clone.
+	// Determine the version we want to checkout.
+	version := t.Version
 	if t.Latest {
-		test.Exec(t.T, "git", "clone", "--quiet", t.Repository.CloneURL(), t.repopath)
-		return
+		version = t.DefaultBranch
 	}
 
+	// Clone. Use a shallow clone to speed up large repositories.
+	t.repopath = filepath.Join(t.WorkDir, t.Name())
 	test.Exec(t.T, "git", "init", t.repopath)
 	test.Exec(t.T, "git", "-C", t.repopath, "remote", "add", "origin", t.Repository.CloneURL())
-	test.Exec(t.T, "git", "-C", t.repopath, "checkout", "--quiet", t.Version)
+	test.Exec(t.T, "git", "-C", t.repopath, "fetch", "--depth=1", "origin", version)
+	test.Exec(t.T, "git", "-C", t.repopath, "checkout", "FETCH_HEAD")
 }
 
 func (t *PackageTest) steps() {

--- a/tests/thirdparty/packages_test.go
+++ b/tests/thirdparty/packages_test.go
@@ -71,16 +71,16 @@ func (t *PackageTest) Run() {
 
 // checkout the code at the specified version.
 func (t *PackageTest) checkout() {
-	// Clone repo.
-	dst := filepath.Join(t.WorkDir, t.Name())
-	test.Exec(t.T, "git", "clone", "--quiet", t.Repository.CloneURL(), dst)
-	t.repopath = dst
+	t.repopath = filepath.Join(t.WorkDir, t.Name())
 
-	// Checkout specific version.
+	// If latest, do a regular clone.
 	if t.Latest {
-		t.Log("using latest version")
+		test.Exec(t.T, "git", "clone", "--quiet", t.Repository.CloneURL(), t.repopath)
 		return
 	}
+
+	test.Exec(t.T, "git", "init", t.repopath)
+	test.Exec(t.T, "git", "-C", t.repopath, "remote", "add", "origin", t.Repository.CloneURL())
 	test.Exec(t.T, "git", "-C", t.repopath, "checkout", "--quiet", t.Version)
 }
 


### PR DESCRIPTION
When trying to add a test case from the standard library, cloning golang/go
was taking forever. This PR switches to a shallow clone.