### PR TITLE
.github: exclude bot commits from auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - cadobot


### PR DESCRIPTION
`cadobot` generates many uninteresting commits. Exclude them from the
auto-generated release notes generated by Github.

Reference:
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes