### PR TITLE
.github/actions: fix bot author template

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -47,7 +47,7 @@ runs:
       with:
         token: ${{ steps.app.outputs.token }}
         commit-message: ${{ inputs.title }}
-        author: "{{ steps.bot.outputs.login }} <${{ steps.bot.outputs.id }}+${{ steps.bot.outputs.login }}@users.noreply.github.com>"
+        author: "${{ steps.bot.outputs.login }} <${{ steps.bot.outputs.id }}+${{ steps.bot.outputs.login }}@users.noreply.github.com>"
         branch: ${{ inputs.branch }}
         base: master
         delete-branch: true


### PR DESCRIPTION
Many bot commits have landed with an incorrectly templated author name, for example 67039b7ed96f015818f68be22f009bd9b6ed910d has:

```
Co-authored-by: {{ steps.bot.outputs.login }} <104697117+cadobot[bot]@users.noreply.github.com>
```

This PR fixes the bad template.