### PR TITLE
Revert "script: fix golangci-lint install (#368)"

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,11 +4,8 @@
 go install ./internal/cmd/asmvet
 
 # golangci-lint for linting
-#
-# Note: we pin a different version of the install script to fix
-# https://github.com/golangci/golangci-lint/issues/3509.
 golangci_lint_version='v1.49.0'
-golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/d57156ec228b712ccd429367482771179e3fa050/install.sh"
+golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
 curl -sfL "${golangci_install_script}" | sh -s -- -b "$GOPATH/bin" "${golangci_lint_version}"
 
 # embedmd required for documentation generation


### PR DESCRIPTION
This reverts commit b2ed9c77ec7510920d49dd882bc03735dfe9b774.

It seems Github fixed the underlying issue:

https://github.com/orgs/community/discussions/45590#discussioncomment-4802887