### PR TITLE
ci: remove "Configure Go Environment" step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
-      - name: Configure Go Environment
-        run: |
-          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
-          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
-      - name: Go Environment
-        run: go env
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
@@ -68,12 +62,6 @@ jobs:
         with:
           go-version: 1.19.x
           check-latest: true
-      - name: Configure Go Environment
-        run: |
-          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
-          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
-      - name: Go Environment
-        run: go env
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -13,12 +13,6 @@ jobs:
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
           go-version: 1.19.x
-      - name: Configure Go Environment
-        run: |
-          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
-          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
-      - name: Go Environment
-        run: go env
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -15,12 +15,6 @@ jobs:
         with:
           go-version: 1.19.x
           check-latest: true
-      - name: Configure Go Environment
-        run: |
-          echo GOPATH=${{ runner.workspace }} >> $GITHUB_ENV
-          echo ${{ runner.workspace }}/bin >> $GITHUB_PATH
-      - name: Go Environment
-        run: go env
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,7 +6,7 @@ go install ./internal/cmd/asmvet
 # golangci-lint for linting
 golangci_lint_version='v1.49.0'
 golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
-curl -sfL "${golangci_install_script}" | sh -s -- -b "$GOPATH/bin" "${golangci_lint_version}"
+curl -sfL "${golangci_install_script}" | sh -s -- -b "$(go env GOPATH)/bin" "${golangci_lint_version}"
 
 # embedmd required for documentation generation
 go install github.com/campoy/embedmd@v1.0.0


### PR DESCRIPTION
No longer required given updates to `actions/setup-go`.