### PR TITLE
tests/thirdparty: update golang/go tests to go1.20.1

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -947,7 +947,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: golang/go
-          ref: go1.20rc2
+          ref: go1.20.1
           path: go
           persist-credentials: false
       - name: Compile Go Toolchain
@@ -985,7 +985,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           repository: golang/go
-          ref: go1.20rc2
+          ref: go1.20.1
           path: go
           persist-credentials: false
       - name: Compile Go Toolchain

--- a/tests/thirdparty/suite.json
+++ b/tests/thirdparty/suite.json
@@ -749,7 +749,7 @@
                 "stars": 108950
             },
             "default_branch": "master",
-            "version": "go1.20rc2",
+            "version": "go1.20.1",
             "packages": [
                 {
                     "pkg": "src/crypto/internal/bigmod",


### PR DESCRIPTION
The Go third-party compatibility tests were pinned to the release candidate version. This change uses the now official Go 1.20.1 release tag.