### PR TITLE
Update make_const.go floating point format verb

### DIFF
--- a/operand/make_const.go
+++ b/operand/make_const.go
@@ -38,7 +38,7 @@ func PrintConstTypes(w io.Writer) {
 		bs := strconv.Itoa(bits)
 
 		if n >= 4 {
-			PrintConstType(w, "F"+bs, "float"+bs, "(%#v)", n, fmt.Sprintf("F%d is a %d-bit floating point constant.", bits, bits))
+			PrintConstType(w, "F"+bs, "float"+bs, "(%#f)", n, fmt.Sprintf("F%d is a %d-bit floating point constant.", bits, bits))
 		}
 		PrintConstType(w, "I"+bs, "int"+bs, "%+d", n, fmt.Sprintf("I%d is a %d-bit signed integer constant.", bits, bits))
 		PrintConstType(w, "U"+bs, "uint"+bs, "%#0"+strconv.Itoa(2*n)+"x", n, fmt.Sprintf("U%d is a %d-bit unsigned integer constant.", bits, bits))


### PR DESCRIPTION
Change floating point format verb to `%#f` from `%#v` to ensure floating point constants are always printed with a decimal, ensuring they will be correctly interpreted by the Go assembler. Closes #387.