### PR TITLE
ci: bump to go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.20.x, 1.21.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -49,7 +49,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -77,7 +77,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -52,7 +52,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -98,7 +98,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -145,7 +145,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -180,7 +180,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -217,7 +217,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -252,7 +252,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -290,7 +290,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -325,7 +325,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -360,7 +360,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -410,7 +410,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -461,7 +461,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -514,7 +514,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -567,7 +567,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -612,7 +612,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -647,7 +647,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -684,7 +684,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -721,7 +721,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -756,7 +756,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -791,7 +791,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -826,7 +826,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -861,7 +861,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -901,7 +901,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -936,7 +936,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -974,7 +974,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -1012,7 +1012,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -1047,7 +1047,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -1082,7 +1082,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout avo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0

--- a/tests/thirdparty/make_workflow.go
+++ b/tests/thirdparty/make_workflow.go
@@ -101,7 +101,7 @@ func GenerateWorkflow(s *thirdparty.Suite) ([]byte, error) {
 		g.Linef("- name: Install Go")
 		g.Linef("  uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1")
 		g.Linef("  with:")
-		g.Linef("    go-version: 1.20.x")
+		g.Linef("    go-version: 1.21.x")
 		g.Linef("    check-latest: true")
 
 		// Checkout avo.


### PR DESCRIPTION
- .github: bump to go 1.21
- tests/thirdparty: update workflow generator to 1.21
