### PR TITLE
all: upgrade to golangci-lint v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,12 +14,14 @@ linters:
     - funlen
     - gochecknoglobals
     - gochecknoinits
+    - goconst
     - godox
     - goerr113
     - golint
     - gomnd
     - gosec
     - ifshort
+    - inamedparam
     - interfacer
     - ireturn
     - lll
@@ -29,6 +31,7 @@ linters:
     - nosnakecase
     - paralleltest
     - prealloc
+    - perfsprint
     - rowserrcheck
     - scopelint
     - structcheck
@@ -42,15 +45,56 @@ linters:
     - wsl
 linters-settings:
   depguard:
-    list-type: whitelist
-    packages:
-      - github.com/mmcloughlin/avo
-      - golang.org/x/
+    rules:
+      main:
+        allow:
+          - github.com/mmcloughlin/avo
+          - golang.org/x/
+          - $gostd
   gci:
     sections:
       - standard
       - default
       - prefix(github.com/mmcloughlin/avo)
+  revive:
+    enable-all-rules: true
+    rules:
+      - name: add-constant
+        disabled: true
+      - name: confusing-results
+        disabled: true
+      - name: cognitive-complexity
+        disabled: true
+      - name: cyclomatic
+        disabled: true
+      - name: deep-exit
+        disabled: true
+      - name: empty-block
+        disabled: true
+      - name: flag-parameter
+        disabled: true
+      - name: function-length
+        disabled: true
+      - name: if-return
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: modifies-value-receiver
+        disabled: true
+      - name: unexported-naming
+        disabled: true
+      - name: unhandled-error
+        arguments:
+          - 'fmt\.(P|Fp)rint(ln|f)?'
+          - 'text/tabwriter\.Writer\.Flush'
+      - name: unused-parameter
+        disabled: true
+      - name: unused-receiver
+        disabled: true
+      - name: use-any
+        disabled: true
 issues:
   exclude-use-default: false
   exclude:

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,7 +4,7 @@
 go install ./internal/cmd/asmvet
 
 # golangci-lint for linting
-golangci_lint_version='v1.51.2'
+golangci_lint_version='v1.55.2'
 golangci_install_script="https://raw.githubusercontent.com/golangci/golangci-lint/${golangci_lint_version}/install.sh"
 curl -sfL "${golangci_install_script}" | sh -s -- -b "$(go env GOPATH)/bin" "${golangci_lint_version}"
 


### PR DESCRIPTION
Upgrade `golangci-lint` to address a bug triggered since Go 1.21.5.

See: golangci/golangci-lint#3718
See: golang/go#64592
