### PR TITLE
all: enable use-any revive rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,8 +93,6 @@ linters-settings:
         disabled: true
       - name: unused-receiver
         disabled: true
-      - name: use-any
-        disabled: true
 issues:
   exclude-use-default: false
   exclude:

--- a/build/context.go
+++ b/build/context.go
@@ -166,7 +166,7 @@ func (c *Context) Comment(lines ...string) {
 }
 
 // Commentf adds a formtted comment line.
-func (c *Context) Commentf(format string, a ...interface{}) {
+func (c *Context) Commentf(format string, a ...any) {
 	c.Comment(fmt.Sprintf(format, a...))
 }
 

--- a/build/global.go
+++ b/build/global.go
@@ -154,7 +154,7 @@ func Label(name string) { ctx.Label(name) }
 func Comment(lines ...string) { ctx.Comment(lines...) }
 
 // Commentf adds a formtted comment line.
-func Commentf(format string, a ...interface{}) { ctx.Commentf(format, a...) }
+func Commentf(format string, a ...any) { ctx.Commentf(format, a...) }
 
 // ConstData builds a static data section containing just the given constant.
 func ConstData(name string, v operand.Constant) operand.Mem { return ctx.ConstData(name, v) }

--- a/gotypes/components.go
+++ b/gotypes/components.go
@@ -45,7 +45,7 @@ type Component interface {
 // methods whilst also allowing method chaining to continue.
 type componenterr string
 
-func errorf(format string, args ...interface{}) Component {
+func errorf(format string, args ...any) Component {
 	return componenterr(fmt.Sprintf(format, args...))
 }
 

--- a/internal/cmd/docgen/main.go
+++ b/internal/cmd/docgen/main.go
@@ -71,7 +71,7 @@ func mainerr() (err error) {
 	}
 
 	// Execute.
-	data := map[string]interface{}{
+	data := map[string]any{
 		"Suite": suite,
 	}
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -86,7 +86,7 @@ func (c *Client) Issue(ctx context.Context, owner, name string, number int) (*Is
 	return issue, nil
 }
 
-func (c *Client) request(req *http.Request, payload interface{}) (err error) {
+func (c *Client) request(req *http.Request, payload any) (err error) {
 	// Add common headers.
 	if c.token != "" {
 		req.Header.Set("Authorization", "Bearer "+c.token)

--- a/internal/prnt/printer.go
+++ b/internal/prnt/printer.go
@@ -43,13 +43,13 @@ func (g *Generator) Dedent() {
 }
 
 // Linef prints formatted output terminated with a new line.
-func (g *Generator) Linef(format string, args ...interface{}) {
+func (g *Generator) Linef(format string, args ...any) {
 	g.Printf(format, args...)
 	g.NL()
 }
 
 // Printf prints to the internal buffer.
-func (g *Generator) Printf(format string, args ...interface{}) {
+func (g *Generator) Printf(format string, args ...any) {
 	if g.err != nil {
 		return
 	}

--- a/operand/checks_test.go
+++ b/operand/checks_test.go
@@ -182,6 +182,6 @@ func TestChecks(t *testing.T) {
 	}
 }
 
-func funcname(f interface{}) string {
+func funcname(f any) string {
 	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 }

--- a/pass/cfg_test.go
+++ b/pass/cfg_test.go
@@ -266,7 +266,7 @@ func AssertPredecessors(t *testing.T, f *ir.Function, expect map[string][]string
 	AssertEqual(t, "predecessors", OpcodePredecessorGraph(f), expect)
 }
 
-func AssertEqual(t *testing.T, what string, got, expect interface{}) {
+func AssertEqual(t *testing.T, what string, got, expect any) {
 	t.Helper()
 	t.Logf("%s=%#v\n", what, got)
 	if reflect.DeepEqual(expect, got) {


### PR DESCRIPTION
Enable the `use-any` `revive` rule which requires replacing the empty
interface `interface{}` with `any`.
