### PR TITLE
tests/thirdparty: add bytedance/gopkg

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1111,3 +1111,45 @@ jobs:
       - name: Test
         working-directory: circl/simd/keccakf1600
         run: go test ./...
+  bytedance-gopkg-util-xxhash3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # v3.3.1
+        with:
+          go-version: 1.21.x
+          check-latest: true
+      - name: Checkout avo
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          path: avo
+          persist-credentials: false
+      - name: Checkout bytedance/gopkg
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          repository: bytedance/gopkg
+          ref: a5eedbe96960cf0f801cf970e89f511842daee75
+          path: gopkg
+          persist-credentials: false
+      - name: Setup Generator Module
+        working-directory: gopkg/util/xxhash3/internal/avo
+        run: |
+          sed -i.bak '/build ignore/d' *.go
+          go mod init github.com/bytedance/gopkg/util/xxhash3/internal/avo
+      - name: Avo Module Replacement
+        working-directory: gopkg/util/xxhash3/internal/avo
+        run: |
+          go mod edit -modfile=go.mod -require=github.com/mmcloughlin/avo@v0.0.0-00010101000000-000000000000
+          go mod edit -modfile=go.mod -replace=github.com/mmcloughlin/avo=${{ github.workspace }}/avo
+          go mod tidy -modfile=go.mod
+      - name: Generate
+        working-directory: gopkg/util/xxhash3/internal/avo
+        run: |
+          go run . -avx2 -out ../../avx2_amd64.s
+          go run . -sse2 -out ../../sse2_amd64.s
+      - name: Diff
+        working-directory: gopkg/util/xxhash3
+        run: git diff
+      - name: Test
+        working-directory: gopkg/util/xxhash3
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ Implementations of full algorithms:
 Popular projects[^projects] using `avo`:
 
 [^projects]: Projects drawn from the `avo` third-party test suite. Popularity
-estimated from Github star count collected on Jan 1, 2024.
+estimated from Github star count collected on Jan 9, 2024.
 
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fgolang.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [golang / **go**](https://github.com/golang/go)
-:star: 116.7k
+:star: 116.8k
 > The Go programming language
 
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fklauspost.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [klauspost / **compress**](https://github.com/klauspost/compress)
@@ -210,12 +210,16 @@ estimated from Github star count collected on Jan 1, 2024.
 :star: 1.8k
 > Reed-Solomon Erasure Coding in Go
 
+<img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fbytedance.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [bytedance / **gopkg**](https://github.com/bytedance/gopkg)
+:star: 1.4k
+> Universal Utilities for Go
+
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fcloudflare.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [cloudflare / **circl**](https://github.com/cloudflare/circl)
 :star: 1.1k
 > CIRCL: Cloudflare Interoperable Reusable Cryptographic Library
 
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fsegmentio.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [segmentio / **asm**](https://github.com/segmentio/asm)
-:star: 820
+:star: 821
 > Go library providing algorithms optimized to leverage the characteristics of modern CPUs
 
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fzeebo.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [zeebo / **xxh3**](https://github.com/zeebo/xxh3)
@@ -229,10 +233,6 @@ estimated from Github star count collected on Jan 1, 2024.
 <img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Flukechampine.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [lukechampine / **blake3**](https://github.com/lukechampine/blake3)
 :star: 316
 > A pure-Go implementation of the BLAKE3 cryptographic hash function
-
-<img src="https://images.weserv.nl?fit=cover&h=24&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fminio.png&w=24" width="24" height="24" hspace="4" valign="middle" /> [minio / **md5-simd**](https://github.com/minio/md5-simd)
-:star: 159
-> Accelerate aggregated MD5 hashing performance up to 8x for AVX512 and 4x for AVX2. Useful for server applications that need to compute many MD5 sums in parallel.
 
 See the [full list of projects using `avo`](doc/adopters.md).
 

--- a/doc/adopters.md
+++ b/doc/adopters.md
@@ -16,6 +16,10 @@ Optimized Go Compression Packages
 
 Reed-Solomon Erasure Coding in Go
 
+<img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fbytedance.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [bytedance / **gopkg**](https://github.com/bytedance/gopkg)
+
+Universal Utilities for Go
+
 <img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fcloudflare.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [cloudflare / **circl**](https://github.com/cloudflare/circl)
 
 CIRCL: Cloudflare Interoperable Reusable Cryptographic Library
@@ -40,13 +44,13 @@ A pure-Go implementation of the BLAKE3 cryptographic hash function
 
 Accelerate aggregated MD5 hashing performance up to 8x for AVX512 and 4x for AVX2. Useful for server applications that need to compute many MD5 sums in parallel.
 
-<img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2FFiloSottile.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [FiloSottile / **edwards25519**](https://github.com/FiloSottile/edwards25519)
-
-filippo.io/edwards25519 — A safer, faster, and more powerful low-level edwards25519 Go implementation.
-
 <img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fdgryski.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [dgryski / **go-bloomindex**](https://github.com/dgryski/go-bloomindex)
 
 Bloom-filter based search index
+
+<img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2FFiloSottile.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [FiloSottile / **edwards25519**](https://github.com/FiloSottile/edwards25519)
+
+filippo.io/edwards25519 — A safer, faster, and more powerful low-level edwards25519 Go implementation.
 
 <img src="https://images.weserv.nl?fit=cover&h=28&mask=circle&maxage=7d&url=https%3A%2F%2Fgithub.com%2Fphoreproject.png&w=28" width="28" height="28" hspace="4" valign="middle" /> [phoreproject / **bls**](https://github.com/phoreproject/bls)
 

--- a/tests/thirdparty/suite.json
+++ b/tests/thirdparty/suite.json
@@ -859,6 +859,39 @@
                     ]
                 }
             ]
+        },
+        {
+            "repository": {
+                "owner": "bytedance",
+                "name": "gopkg"
+            },
+            "default_branch": "develop",
+            "version": "a5eedbe96960cf0f801cf970e89f511842daee75",
+            "packages": [
+                {
+                    "pkg": "util/xxhash3",
+                    "module": "internal/avo/go.mod",
+                    "setup": [
+                        {
+                            "name": "Setup Generator Module",
+                            "dir": "internal/avo",
+                            "commands": [
+                                "sed -i.bak '/build ignore/d' *.go",
+                                "go mod init github.com/bytedance/gopkg/util/xxhash3/internal/avo"
+                            ]
+                        }
+                    ],
+                    "generate": [
+                        {
+                            "dir": "internal/avo",
+                            "commands": [
+                                "go run . -avx2 -out ../../avx2_amd64.s",
+                                "go run . -sse2 -out ../../sse2_amd64.s"
+                            ]
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "metadata_last_update": "2024-01-01T05:28:16.191838199Z"

--- a/tests/thirdparty/suite.json
+++ b/tests/thirdparty/suite.json
@@ -171,7 +171,7 @@
             },
             "metadata": {
                 "description": "Reed-Solomon Erasure Coding in Go",
-                "stars": 1754
+                "stars": 1755
             },
             "default_branch": "master",
             "version": "922778284547557265cff0f903ab5f4c27e40ae9",
@@ -230,7 +230,7 @@
             },
             "metadata": {
                 "description": "Optimized Go Compression Packages",
-                "stars": 4320
+                "stars": 4332
             },
             "default_branch": "master",
             "version": "2f236383d7c2faa8ef7e354ccecb926a5b47a24d",
@@ -275,7 +275,7 @@
             },
             "metadata": {
                 "description": "Bloom-filter based search index",
-                "stars": 116
+                "stars": 118
             },
             "default_branch": "master",
             "version": "0902316dce158c154b958ee5cfc706c62af29a42",
@@ -519,7 +519,7 @@
             },
             "metadata": {
                 "description": "Go library providing algorithms optimized to leverage the characteristics of modern CPUs",
-                "stars": 820
+                "stars": 821
             },
             "default_branch": "main",
             "version": "2bf3fdd47b1cdbe8fe020f032caf14891e10a85f",
@@ -634,7 +634,7 @@
             "metadata": {
                 "description": "[mirror] Go supplementary cryptography libraries",
                 "homepage": "https://golang.org/x/crypto",
-                "stars": 2864
+                "stars": 2869
             },
             "default_branch": "master",
             "version": "089bfa5675191fd96a44247682f76ebca03d7916",
@@ -746,7 +746,7 @@
             "metadata": {
                 "description": "The Go programming language",
                 "homepage": "https://go.dev",
-                "stars": 116689
+                "stars": 116833
             },
             "default_branch": "master",
             "version": "go1.20.1",
@@ -817,7 +817,7 @@
             "metadata": {
                 "description": "CIRCL: Cloudflare Interoperable Reusable Cryptographic Library",
                 "homepage": "http://blog.cloudflare.com/introducing-circl",
-                "stars": 1083
+                "stars": 1088
             },
             "default_branch": "main",
             "version": "v1.1.0",
@@ -865,6 +865,10 @@
                 "owner": "bytedance",
                 "name": "gopkg"
             },
+            "metadata": {
+                "description": "Universal Utilities for Go",
+                "stars": 1405
+            },
             "default_branch": "develop",
             "version": "a5eedbe96960cf0f801cf970e89f511842daee75",
             "packages": [
@@ -894,5 +898,5 @@
             ]
         }
     ],
-    "metadata_last_update": "2024-01-01T05:28:16.191838199Z"
+    "metadata_last_update": "2024-01-09T01:47:54.01555539Z"
 }


### PR DESCRIPTION
Adds the https://github.com/bytedance/gopkg `xxhash3` package to the
third-party test suite.
