### PR TITLE
.github: add supply chain analysis and release documents

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -29,19 +29,26 @@ runs:
   steps:
     - name: Get Bot User
       id: bot
-      uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        # Read from the environment rather than interpolated into the script,
+        # so its contents cannot be treated as JavaScript.
+        BOT: ${{ inputs.bot }}
       with:
         script: |
-          const res = await github.rest.users.getByUsername({username: '${{ inputs.bot }}'});
+          const res = await github.rest.users.getByUsername({username: process.env.BOT});
           for (const [key, value] of Object.entries(res.data)) {
             core.setOutput(key, value)
           }
     - name: Generate App Token
-      uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: app
       with:
-        app_id: ${{ inputs.app_id }}
-        private_key: ${{ inputs.app_private_key }}
+        app-id: ${{ inputs.app_id }}
+        private-key: ${{ inputs.app_private_key }}
+        # Only what is needed to push a branch and open a pull request.
+        permission-contents: write
+        permission-pull-requests: write
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@331d02c7e2104af23ad5974d4d5cbc58a3e6dc77 # v4.2.2
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: codeql
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "41 9 * * 1"
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.26.x
+          check-latest: true
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4
+        with:
+          languages: go
+          build-mode: manual
+          queries: security-and-quality
+      # Build explicitly rather than relying on autobuild, which would also
+      # build the generated test packages.
+      - name: Build
+        run: go build ./...
+      - name: Analyze
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4

--- a/.github/workflows/metadata.yml
+++ b/.github/workflows/metadata.yml
@@ -20,11 +20,13 @@ jobs:
       - name: Bootstrap
         run: ./script/bootstrap
       - name: Generate App Token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Reads public repository metadata for the third-party suite.
+          permission-metadata: read
       - name: Update Package Metadata
         env:
           GITHUB_TOKEN: ${{ steps.app.outputs.token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,16 +5,25 @@ on:
   pull_request:
 jobs:
   automerge:
-    if: github.actor == 'cadobot[bot]' && !github.event.pull_request.draft
+    # Identify the bot by account ID rather than by actor name. The name is
+    # attacker-controlled: an account can be renamed to impersonate another,
+    # whereas the ID is stable and unique.
+    if: github.event.pull_request.user.id == 104697117 && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: Generate Bot Token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: bot
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Only what is needed to enable auto-merge on a pull request.
+          permission-contents: write
+          permission-pull-requests: write
       - name: Automerge Bot Pull Requests
-        run: gh pr merge --auto --squash "${{ github.event.pull_request.html_url }}"
+        run: gh pr merge --auto --squash "${PR_URL}"
         env:
           GITHUB_TOKEN: ${{ steps.bot.outputs.token }}
+          # Passed through the environment rather than interpolated into the
+          # script, so its contents cannot be treated as shell syntax.
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: release
+permissions:
+  contents: read
+on:
+  release:
+    types:
+      - published
+  # Allow a dry run against the default branch, which builds the documents but
+  # has no release to attach them to.
+  workflow_dispatch:
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to attach the documents to the release.
+      contents: write
+      # Required to record the attestations.
+      id-token: write
+      attestations: write
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.26.x
+          check-latest: true
+          # This job publishes artifacts, so do not let a poisoned module
+          # cache contribute to them.
+          cache: false
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Resolve the module graph up front so the dependencies recorded in the
+      # documents below are the ones the release actually builds against.
+      - name: Download Modules
+        run: go mod download
+      - name: Generate SPDX Document
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: spdx-json
+          output-file: avo.spdx.json
+          artifact-name: avo.spdx.json
+          upload-release-assets: true
+      - name: Generate CycloneDX Document
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: avo.cdx.json
+          artifact-name: avo.cdx.json
+          upload-release-assets: true
+      # avo is consumed as a module rather than as a binary, so there is no
+      # release artifact to attest. Record provenance for the documents
+      # themselves, which is what a consumer can independently verify.
+      - name: Attest Provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            avo.spdx.json
+            avo.cdx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: scorecard
+permissions:
+  contents: read
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "8 4 * * 2"
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required to upload the results to code scanning.
+      security-events: write
+      # Required to publish the results, which is what allows the score to be
+      # read by third parties such as deps.dev.
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run Analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload Results
+        uses: github/codeql-action/upload-sarif@d1ba80a13dd99fba24a470575428917156a28b43 # v4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/thirdparty.yml
+++ b/.github/workflows/thirdparty.yml
@@ -25,11 +25,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Generate App Token
-        uses: tibdex/github-app-token@021a2405c7f990db57f5eae5397423dcc554159c # v1.7.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Reads public repositories, and raises the API rate limit.
+          permission-contents: read
       - name: Run Third-Party Tests
         working-directory: tests/thirdparty
         env:

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -1,0 +1,23 @@
+name: vuln
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "52 7 * * 3"
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-input: 1.26.x
+          check-latest: true

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,45 @@
+name: workflows
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/**"
+  pull_request:
+    paths:
+      - ".github/**"
+jobs:
+  # actionlint checks the workflow files themselves: expression syntax, runner
+  # labels, shell scripting in run steps.
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.26.x
+          check-latest: true
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - name: Run actionlint
+        run: actionlint
+  # zizmor audits the same files for supply-chain weaknesses, such as unpinned
+  # actions and over-broad permissions.
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <img src="https://img.shields.io/github/actions/workflow/status/mmcloughlin/avo/ci.yml?style=flat-square" alt="Build Status" />
   <a href="https://pkg.go.dev/github.com/mmcloughlin/avo"><img src="https://img.shields.io/badge/doc-reference-007d9b?logo=go&style=flat-square" alt="go.dev" /></a>
   <a href="https://goreportcard.com/report/github.com/mmcloughlin/avo"><img src="https://goreportcard.com/badge/github.com/mmcloughlin/avo?style=flat-square" alt="Go Report Card" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/mmcloughlin/avo"><img src="https://api.scorecard.dev/projects/github.com/mmcloughlin/avo/badge?style=flat-square" alt="OpenSSF Scorecard" /></a>
 </p>
 
 <p align="center">Generate x86 Assembly with Go</p>

--- a/internal/cmd/docgen/templates/readme.tmpl
+++ b/internal/cmd/docgen/templates/readme.tmpl
@@ -4,6 +4,7 @@
   <img src="https://img.shields.io/github/actions/workflow/status/mmcloughlin/avo/ci.yml?style=flat-square" alt="Build Status" />
   <a href="https://pkg.go.dev/github.com/mmcloughlin/avo"><img src="https://img.shields.io/badge/doc-reference-007d9b?logo=go&style=flat-square" alt="go.dev" /></a>
   <a href="https://goreportcard.com/report/github.com/mmcloughlin/avo"><img src="https://goreportcard.com/badge/github.com/mmcloughlin/avo?style=flat-square" alt="Go Report Card" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/mmcloughlin/avo"><img src="https://api.scorecard.dev/projects/github.com/mmcloughlin/avo/badge?style=flat-square" alt="OpenSSF Scorecard" /></a>
 </p>
 
 <p align="center">Generate x86 Assembly with Go</p>


### PR DESCRIPTION
Adds the static analysis, dependency auditing and release provenance that the OpenSSF Scorecard checks look for. Independent of #490 — both branch from `master`, though they overlap on four files (see the end).

## Why

[deps.dev's view of avo](https://deps.dev/go/github.com%2Fmmcloughlin%2Favo/v0.6.0) currently reports no SAST, no Scorecard results, and no SBOM. The repository has no CodeQL, no Scorecard workflow, and no release automation at all — v0.6.0 was cut by hand, so nothing generates or publishes a dependency document.

## New workflows

**`codeql`** — CodeQL for Go on push, pull request and weekly, with the `security-and-quality` suite. Builds explicitly rather than via autobuild, to avoid building the generated test packages.

**`scorecard`** — OpenSSF Scorecard weekly and on push. `publish_results: true` is what makes the score readable by third parties like deps.dev; results also upload to code scanning. Adds a badge to the readme *template* (`README.md` is generated, so the badge goes in `internal/cmd/docgen/templates/readme.tmpl` and the regenerated README is included).

**`vuln`** — `govulncheck` on push, pull request and weekly.

**`workflows`** — `actionlint` (workflow syntax, runner labels, shell in `run:` steps) and `zizmor` (supply-chain auditing of the workflows themselves). `actionlint` installs via `go install` rather than adding another action dependency.

**`release`** — on publishing a release, generates SPDX and CycloneDX documents and attaches them as release assets. Triggered by `release: published`, so it fits the existing manual release flow: you cut the release, the automation attaches the documents.

A note on that last one: avo is consumed as a module, not as a binary, so there is no build artifact to attest. Provenance is recorded for the documents themselves, which is the claim a consumer can actually verify. If you'd rather not have attestations at all, that step drops cleanly. Module caching is disabled in this job specifically, so a poisoned cache cannot contribute to what gets published — zizmor flagged that on my first draft.

## What the audits found in the existing workflows

These are fixed here because the `workflows` job cannot be green otherwise:

- **`tibdex/github-app-token` is archived.** Replaced with `actions/create-github-app-token`, and each token request is now scoped with `permission-*` inputs to what its consumer actually does, rather than taking the app's full installation rights.
- **The automerge condition was spoofable.** `pr.yml` gated on `github.actor == 'cadobot[bot]'`. Account names can be changed, so an account can be renamed to impersonate another; it now compares the numeric account ID, which is stable and unique.
- **Two template injections.** `github.event.pull_request.html_url` was interpolated straight into a shell command, and `inputs.bot` into a JavaScript snippet. Both now pass through the environment so their contents cannot be treated as syntax.

The last two are worth a look independently of this PR — the automerge one is the reason I'd suggest not adding dependabot to that condition.

## Verification

`actionlint` clean; `zizmor --persona=regular` reports **no findings** across all workflows (from 5 high before). `script/fmt` and `script/doc` produce zero drift.

I can't exercise the GitHub-side jobs from a fork — CodeQL, Scorecard publishing and the release/attestation steps need to run in the repository itself, and `scorecard`'s `publish_results` only works on the upstream default branch. Those are worth watching on their first run.

## Overlap with the other PR

The `create-github-app-token` replacement appears in both. Overlapping files: `pr.yml`, `metadata.yml`, `thirdparty.yml`, `actions/create-pull-request/action.yml`. Whichever lands second needs a trivial rebase there. Order does not matter.
